### PR TITLE
Toggle for number and relativenumber

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -10,9 +10,11 @@ Installation
 Usage
 -----
 Press `<F12>` to toggle mouse focus between Vim and your terminal emulator,
-allowing terminal emulator mouse commands, like copy/paste.
+allowing terminal emulator mouse commands, like copy/paste. `<F12>` also
+removes line numbers for easy copying.
 
-Toggling restores the Vim 'mouse' option value to its previous value.
+Toggling restores the Vim 'mouse' option value to its previous value. Line
+number settings are also restored.
 
 
 Customization

--- a/plugin/toggle_mouse.vim
+++ b/plugin/toggle_mouse.vim
@@ -17,10 +17,16 @@ fun! s:ToggleMouse()
 
     if &mouse == ""
         let &mouse = s:old_mouse
+        let &number = s:old_number
+        let &relativenumber = s:old_relativenumber
         echo "Mouse is for Vim (" . &mouse . ")"
     else
         let s:old_mouse = &mouse
-        let &mouse=""
+        let &mouse = ""
+        let s:old_number = &number
+        let s:old_relativenumber = &relativenumber
+        set nonumber
+        set norelativenumber
         echo "Mouse is for terminal"
     endif
 endfunction


### PR DESCRIPTION
This edit should also toggle line numbers with <F12>.

I was using this to copy with mouse from vim, so not having numbers in terminal mouse mode is useful.